### PR TITLE
Default routing for sample weight

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -507,7 +507,11 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
         default_requests = super().__sklearn_default_request__()
         for method_name in ("fit", "score"):
             method = getattr(self, method_name, None)
-            if "sample_weight" in inspect.signature(method).parameters:
+            if (
+                method is not None
+                and "sample_weight" in inspect.signature(method).parameters
+            ):
+
                 default_requests[method_name]["sample_weight"] = True
 
         return default_requests

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -498,6 +498,20 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
         )
         _check_feature_names(self, *args, **kwargs)
 
+    def __sklearn_default_request__(self):
+        # sample_weight is requested by default in `fit` and `score` methods
+        # that actually accept it. This ensures that scikit-learn estimators
+        # implement the expected sample_weight semantics consistently. See the
+        # following reference for more details:
+        # https://scikit-learn.org/stable/glossary.html#term-sample_weight
+        default_requests = super().__sklearn_default_request__()
+        for method_name in ("fit", "score"):
+            method = getattr(self, method_name, None)
+            if "sample_weight" in inspect.signature(method).parameters:
+                default_requests[method_name]["sample_weight"] = True
+
+        return default_requests
+
 
 class ClassifierMixin:
     """Mixin class for all classifiers in scikit-learn.


### PR DESCRIPTION
Actually implement the default routing policy for `sample_weight`. I updated @antoinebaker's `test_search_cv_sample_weight_equivalence` to check that we have consistent semantics when metadata routing is disabled. 

Question: shall we do the same for the `groups` metadata in the base splitter class to respect the intent of the changelog entry of https://github.com/scikit-learn/scikit-learn/pull/30946?